### PR TITLE
Create a "DataTemplate" class to allow people to output data-driven narratives

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Mark Rickerby
+Copyright (c) 2016 Tariq Ali
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ tokoyo_electric_writer.result
 # => ""
 ```
 
-By simply specifying a few `meta-rules` with conditionals and Grammars, you can generate unique, readable narratives based on your data.
+By simply specifying a few "meta-rules" with conditionals and Grammars, you can generate unique, readable narratives based on your data.
 ```ruby
 class StockWriter < Calyx::DataTemplate
  def write_narrative

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ greeting.result
 # > "Hello World."
 ```
 
-##Calyx::Grammar
+### Calyx::Grammar
 Obviously, "Hello World" isn’t very interesting by itself. Possible variations can be added to the text using the `rule` constructor to provide a named set of text strings and the rule delimiter syntax (`{}`) within the text strings to substitute the generated content of the rule.
 
 ```ruby
@@ -190,7 +190,7 @@ end
 # => "A pear."
 ```
 
-##Calyx::DataTemplate
+### Calyx::DataTemplate
 Calyx::DataTemplate is useful for allowing a computer to write stories based on data stored within a Hash. The data can be plugged instantly into generated content, so long as you use erb syntax (to distingush from the rule delimiter syntax).
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ end
 
 Calyx is open source and provided under the terms of the MIT license. Copyright (c) 2015 Mark Rickerby, (c) 2016 Tariq Ali
 
-See the `LICENSE` file [included with the project distribution](https://github.com/maetl/calyx/blob/master/LICENSE) for more information.
+See the `LICENSE` file [included with the project distribution](https://github.com/tra38/calyx/blob/master/LICENSE) for more information.
 
 ## Disclaimer
 In the real world, you would probably not want to buy or sell Japanese stock based solely on EPS. [The MIT Encyclopedia of the Japanese Economy](https://books.google.com/books?id=0RS0CGUaef8C&pg=PA423&lpg=PA423&dq=high+earnings+per+share+in+japan&source=bl&ots=sR8KV0fBTk&sig=qHspeX72SmpsU25wz9AZnhaAxyU&hl=en&sa=X&ved=0ahUKEwjcnqqctrLKAhWKRiYKHdKACaoQ6AEIHDAA#v=onepage&q=high%20earnings%20per%20share%20in%20japan&f=false) can provide some reasons why.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Calyx provides a simple API for generating text with declarative recursive gramm
 ### Command Line
 
 ```
-gem install calyx
+gem install tra38-calyx
 ```
 
 ## Gemfile
 
 ```
-gem 'calyx'
+gem 'tra38-calyx'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ gem 'tra38-calyx'
 ```
 
 ## Usage
-
-Calyx support two types of classes.
+To construct rules for generating text, you must first require "calyx", and then inherit from either the `Calyx::Grammar` class or the `Calyx::DataTemplate` class.
 
 Classes that inherit from `Calyx::Grammar` are used to construct a set of rules that can generate a text. All grammars require a `start` rule, which specifies the starting point for generating the text structure.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Calyx provides a simple API for generating text with declarative recursive gramm
 gem install tra38-calyx
 ```
 
-## Gemfile
+### Gemfile
 
 ```
 gem 'tra38-calyx'
@@ -278,6 +278,21 @@ See the `LICENSE` file [included with the project distribution](https://github.c
 In November 2015, Mark Rickerby created Calyx and used that gem to create [choose-your-own adventure gamebooks](https://github.com/dariusk/NaNoGenMo-2015/issues/189). He later on wrote a [blog post](http://maetl.net/notes/storyboard/gamebook-of-dungeon-tropes) explaining his thought process.
 
 In January 2016, Tariq Ali forked Calyx and started adding in new features to turn Calyx into a useful tool for generating data-driven narratives (robojournalism).
+
+##Contributions
+We welcome contributions! Here is a step-by-step guide.
+
+1. Fork it ( https://github.com/tra38/calyx/fork )
+2. Create your feature branch (git checkout -b my-new-feature)
+3. Commit your changes (git commit -am 'Add some feature')
+4. Push to the branch (git push origin my-new-feature)
+5. Create a new Pull Request
+
+###Planned Features
+If you have any suggestions or bug reports, please report them on the [issue tracker](https://github.com/tra38/calyx/issues). Thank you.
+
+- [Produce Listicles](https://github.com/tra38/calyx/issues/1)
+- [Determine Mean, Median, Mode, etc. of a Large Dataset](https://github.com/tra38/calyx/issues/2)
 
 ## Disclaimer
 In the real world, you would probably not want to buy or sell Japanese stock based solely on EPS. [The MIT Encyclopedia of the Japanese Economy](https://books.google.com/books?id=0RS0CGUaef8C&pg=PA423&lpg=PA423&dq=high+earnings+per+share+in+japan&source=bl&ots=sR8KV0fBTk&sig=qHspeX72SmpsU25wz9AZnhaAxyU&hl=en&sa=X&ved=0ahUKEwjcnqqctrLKAhWKRiYKHdKACaoQ6AEIHDAA#v=onepage&q=high%20earnings%20per%20share%20in%20japan&f=false) can provide some reasons why.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or, you can generate text by initializing the Calyx::DataTemplate class and call
 ```ruby
 greeting = Greeting.new
 greeting.result
-# > "Hello world."
+# > "Hello World."
 ```
 
 ##Calyx::Grammar

--- a/README.md
+++ b/README.md
@@ -18,25 +18,43 @@ gem 'calyx'
 
 ## Usage
 
-Require the library and inherit from `Calyx::Grammar` to construct a set of rules to generate a text. All grammars require a `start` rule, which specifies the starting point for generating the text structure.
+Calyx support two types of classes.
+
+Classes that inherit from `Calyx::Grammar` are used to construct a set of rules that can generate a text. All grammars require a `start` rule, which specifies the starting point for generating the text structure.
+
+Classes that inherit from `Calyx::DataTemplate` are used to construct a set of "meta-rules" that will invoke Grammar rules for you. All templates require a `write_narrative` method which specifies what "meta-rules" are being called.
 
 ```ruby
 require 'calyx'
 
 class HelloWorld < Calyx::Grammar
-  start 'Hello world.'
+ start "Hello World."
+end
+
+class Greeting < Calyx::DataTemplate
+ def write_narrative
+  write HelloWorld
+ end
 end
 ```
 
-To generate the text itself, initialize the object and call the `generate` method.
+There are two ways to generate text. You can generate text using Calyx::Grammar by initializing the object and calling the `generate` method.
 
 ```ruby
 hello = HelloWorld.new
 hello.generate
+# > "Hello <%= planet %>."
+```
+
+Or, you can generate text by initializing the Calyx::DataTemplate class and calling the `result` method.
+```ruby
+greeting = Greeting.new
+greeting.result
 # > "Hello world."
 ```
 
-Obviously, this hardcoded sentence isn’t very interesting by itself. Possible variations can be added to the text using the `rule` constructor to provide a named set of text strings and the rule delimiter syntax (`{}`) within the text strings to substitute the generated content of the rule.
+##Calyx::Grammar
+Obviously, "Hello World" isn’t very interesting by itself. Possible variations can be added to the text using the `rule` constructor to provide a named set of text strings and the rule delimiter syntax (`{}`) within the text strings to substitute the generated content of the rule.
 
 ```ruby
 class HelloWorld < Calyx::Grammar
@@ -172,8 +190,88 @@ end
 # => "A pear."
 ```
 
+##Calyx::DataTemplate
+Calyx::DataTemplate is useful for allowing a computer to write stories based on data stored within a Hash. The data can be plugged instantly into generated content, so long as you use erb syntax (to distingush from the rule delimiter syntax).
+
+```ruby
+class StockReport < Calyx::Grammar
+ start "The price of one share of <%= name %> on <%= date %> is <%= price %> Yen."
+end
+
+class StockWriter < Calyx::DataTemplate
+ def write_narrative
+  write StockReport
+ end
+end
+
+cyberdyne = { :name => "Cyberdyne", :price => 1897.0, :date => Date.new(2015,1,14) }
+
+stock_writer = StockWriter.new(cyberdyne)
+stock_writer.result
+# => "The price of one share of Cyberdyne on 2015-01-14 is 1897.0 Yen."
+```
+
+`conditional_write` allows Calyx::DataTemplate to choose what grammar rule to invoke. If the condition is true, use the first grammar; otherwise, use the second grammar.
+```ruby
+class GoodStock < Calyx::Grammar
+ start "You should buy stock in <%= name %> because this company has a low EPS."
+end
+
+class BadStock < Calyx:Grammar
+ start "You should sell stock in <%= name %> because this company has a high EPS."
+end
+
+class StockWriter < Calyx::DataTemplate
+ def write_narrative
+  conditional_write eps <= 20, GoodStock, BadStock
+ end
+end
+
+mitsui = { :name => "Mitsui", :eps => 15.8}
+mitsui_writer = StockWriter.new(mitsui)
+mitsui_writer.result
+# => "You should buy stock in Mitsui because this company has a low EPS."
+
+tokoyo_electric = { :name => "Tokyo Electric Power", :eps => 275.2 }
+tokoyo_electric_writer = StockWriter.new(tokoyo_electric)
+tokoyo_electric_writer.result
+# => "You should sell stock in Tokoyo Electric Power because this company has a high EPS."
+```
+
+You may also only provide only one grammar for `conditional_write`. If the condition is false, then nothing will be written.
+```ruby
+class StockWriter < Calyx::DataTemplate
+ def write_narrative
+  conditional_write eps <= 20, GoodStock
+ end
+end
+
+tokoyo_electric = { :name => "Tokyo Electric Power", :eps => 275.2 }
+tokoyo_electric_writer = StockWriter.new(tokoyo_electric)
+tokoyo_electric_writer.result
+# => ""
+```
+
+By simply specifying a few `meta-rules` with conditionals and Grammars, you can generate unique, readable narratives based on your data.
+```ruby
+class StockWriter < Calyx::DataTemplate
+ def write_narrative
+   write StockReport
+   conditional_write eps <= 20, GoodStock, BadStock
+   conditional_write eps <= 10, WonderfulStock
+   conditional_write eps >= 50, AbsolutelyHorribleStock
+   write ThanksForReading
+  end
+end
+```
+
+###
+
 ## License
 
-Calyx is open source and provided under the terms of the MIT license. Copyright (c) 2015 Mark Rickerby
+Calyx is open source and provided under the terms of the MIT license. Copyright (c) 2015 Mark Rickerby, (c) 2016 Tariq Ali
 
 See the `LICENSE` file [included with the project distribution](https://github.com/maetl/calyx/blob/master/LICENSE) for more information.
+
+## Disclaimer
+In the real world, you would probably not want to buy or sell Japanese stock based solely on EPS. [The MIT Encyclopedia of the Japanese Economy](https://books.google.com/books?id=0RS0CGUaef8C&pg=PA423&lpg=PA423&dq=high+earnings+per+share+in+japan&source=bl&ots=sR8KV0fBTk&sig=qHspeX72SmpsU25wz9AZnhaAxyU&hl=en&sa=X&ved=0ahUKEwjcnqqctrLKAhWKRiYKHdKACaoQ6AEIHDAA#v=onepage&q=high%20earnings%20per%20share%20in%20japan&f=false) can provide some reasons why.

--- a/README.md
+++ b/README.md
@@ -273,5 +273,10 @@ Calyx is open source and provided under the terms of the MIT license. Copyright 
 
 See the `LICENSE` file [included with the project distribution](https://github.com/tra38/calyx/blob/master/LICENSE) for more information.
 
+## History
+In November 2015, Mark Rickerby created Calyx and used that gem to create [choose-your-own adventure gamebooks](https://github.com/dariusk/NaNoGenMo-2015/issues/189). He later on wrote a [blog post](http://maetl.net/notes/storyboard/gamebook-of-dungeon-tropes) explaining his thought process.
+
+In January 2016, Tariq Ali forked Calyx and started adding in new features to turn Calyx into a useful tool for generating data-driven narratives (robojournalism).
+
 ## Disclaimer
 In the real world, you would probably not want to buy or sell Japanese stock based solely on EPS. [The MIT Encyclopedia of the Japanese Economy](https://books.google.com/books?id=0RS0CGUaef8C&pg=PA423&lpg=PA423&dq=high+earnings+per+share+in+japan&source=bl&ots=sR8KV0fBTk&sig=qHspeX72SmpsU25wz9AZnhaAxyU&hl=en&sa=X&ved=0ahUKEwjcnqqctrLKAhWKRiYKHdKACaoQ6AEIHDAA#v=onepage&q=high%20earnings%20per%20share%20in%20japan&f=false) can provide some reasons why.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are two ways to generate text. You can generate text using Calyx::Grammar 
 ```ruby
 hello = HelloWorld.new
 hello.generate
-# > "Hello <%= planet %>."
+# > "Hello World."
 ```
 
 Or, you can generate text by initializing the Calyx::DataTemplate class and calling the `result` method.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ end
 Calyx::DataTemplate is useful for allowing a computer to write stories based on data stored within a Hash. The data can be plugged instantly into generated content, so long as you use erb syntax (to distingush from the rule delimiter syntax).
 
 ```ruby
+require 'date'
+
 class StockReport < Calyx::Grammar
  start "The price of one share of <%= name %> on <%= date %> is <%= price %> Yen."
 end
@@ -217,7 +219,7 @@ class GoodStock < Calyx::Grammar
  start "You should buy stock in <%= name %> because this company has a low EPS."
 end
 
-class BadStock < Calyx:Grammar
+class BadStock < Calyx::Grammar
  start "You should sell stock in <%= name %> because this company has a high EPS."
 end
 

--- a/calyx.gemspec
+++ b/calyx.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'calyx/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'calyx'
+  spec.name          = 'tra38-calyx'
   spec.version       = Calyx::VERSION
-  spec.authors       = ['Mark Rickerby']
-  spec.email         = ['me@maetl.net']
+  spec.authors       = ['Mark Rickerby','Tariq Ali']
+  spec.email         = ['me@maetl.net','tra38@nau.edu']
 
   spec.summary       = %q{Generate text with declarative recursive grammars}
   spec.description   = %q{Calyx provides a simple API for generating text with declarative recursive grammars.}
-  spec.homepage      = 'https://github.com/maetl/calyx'
+  spec.homepage      = 'https://github.com/tra38/calyx'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -185,7 +185,7 @@ module Calyx
     end
 
     def write_narrative
-      #user writes in what he wants to have happened
+      #user writes in what should happened next
       raise "There is no 'write_narrative' method."
     end
 

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module Calyx
   #The Grammar class and the Production module was written by Mark Rickerby in 2015, and licensed under the MIT license.
   class Grammar

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -207,9 +207,13 @@ module Calyx
 
     def publish
       outline = @narrative.join(" ")
-      rough_draft = ERB.new(outline)
-      final_draft = rough_draft.result(binding)
-      final_draft
+      insert_data(outline)
+    end
+
+    private
+    def insert_data(outline)
+      outline = ERB.new(outline)
+      outline.result(binding)
     end
 
   end

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -180,7 +180,11 @@ module Calyx
     attr_reader :data, :narrative
 
     def initialize(data_hash)
-      @data = data_hash
+      #code written with help from jon2992 (IRC name: aegis3121)
+      data_hash.each do |key, value|
+        self.instance_variable_set("@#{key}", value)
+        self.class.send :attr_reader, key
+      end
       write_narrative
     end
 

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -193,7 +193,7 @@ module Calyx
       raise "There is no 'write_narrative' method."
     end
 
-    def write(condition, klass_a, klass_b = nil)
+    def conditional_write(condition, klass_a, klass_b = nil)
       @narrative ||= []
       if condition
         @narrative << klass_a.new.generate

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -189,12 +189,13 @@ module Calyx
       raise "There is no 'write_narrative' method."
     end
 
-    def write(condition, klass_a, klass_b)
+    def write(condition, klass_a, klass_b = nil)
       @narrative ||= []
       if condition
         @narrative << klass_a.new.generate
-      else
+      elsif klass_b
         @narrative << klass_b.new.generate
+      else
       end
     end
 

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 module Calyx
   class Grammar
     class << self

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -198,7 +198,7 @@ module Calyx
       end
     end
 
-    def generate
+    def publish
       @narrative.join(" ")
     end
 

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Calyx
   class Grammar
     class << self
@@ -172,5 +174,32 @@ module Calyx
     def generate
       registry[:start].evaluate
     end
+  end
+
+  class DataTemplate
+    attr_reader :data, :narrative
+    class << self
+      def construct_data(data_hash)
+        @data = data_hash
+      end
+    end
+
+    def initialize(data_hash)
+      @data = data_hash
+    end
+
+    def write(condition, klass_a, klass_b)
+      @narrative ||= []
+      if condition
+        @narrative << klass_a.new.generate
+      else
+        @narrative << klass_b.new.generate
+      end
+    end
+
+    def generate
+      @narrative.join(" ")
+    end
+
   end
 end

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -178,11 +178,6 @@ module Calyx
 
   class DataTemplate
     attr_reader :data, :narrative
-    class << self
-      def construct_data(data_hash)
-        @data = data_hash
-      end
-    end
 
     def initialize(data_hash)
       @data = data_hash

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -178,10 +178,10 @@ module Calyx
     attr_reader :narrative
 
     def initialize(data_hash)
-      #code written with help from jon2992 (IRC name: aegis3121)
       data_hash.each do |key, value|
-        self.instance_variable_set("@#{key}", value)
-        self.class.send :attr_reader, key
+        self.define_singleton_method(:"#{key}") do
+          value
+        end
       end
       @narrative = []
       write_narrative

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -191,6 +191,11 @@ module Calyx
       raise "There is no 'write_narrative' method."
     end
 
+    def write(klass)
+      @narrative ||= []
+      @narrative << klass.new.generate
+    end
+
     def conditional_write(condition, klass_a, klass_b = nil)
       @narrative ||= []
       if condition

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -189,7 +189,7 @@ module Calyx
 
     def write_narrative
       #user writes in what should happened next
-      raise "There is no 'write_narrative' method."
+      raise "There is no 'write_narrative' method present in your class."
     end
 
     def write(klass)

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -205,15 +205,8 @@ module Calyx
       end
     end
 
-    def publish
-      outline = @narrative.join(" ")
-      insert_data(outline)
-    end
-
-    private
-    def insert_data(outline)
-      outline = ERB.new(outline)
-      outline.result(binding)
+    def result
+      ERB.new(@narrative.join(" ")).result(binding)
     end
 
   end

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -186,6 +186,12 @@ module Calyx
 
     def initialize(data_hash)
       @data = data_hash
+      write_narrative
+    end
+
+    def write_narrative
+      #user writes in what he wants to have happened
+      raise "There is no 'write_narrative' method."
     end
 
     def write(condition, klass_a, klass_b)

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -206,7 +206,10 @@ module Calyx
     end
 
     def publish
-      @narrative.join(" ")
+      outline = @narrative.join(" ")
+      rough_draft = ERB.new(outline)
+      final_draft = rough_draft.result(binding)
+      final_draft
     end
 
   end

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -175,7 +175,7 @@ module Calyx
   end
 
   class DataTemplate
-    attr_reader :data, :narrative
+    attr_reader :narrative
 
     def initialize(data_hash)
       #code written with help from jon2992 (IRC name: aegis3121)

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -183,6 +183,7 @@ module Calyx
         self.instance_variable_set("@#{key}", value)
         self.class.send :attr_reader, key
       end
+      @narrative = []
       write_narrative
     end
 
@@ -192,12 +193,10 @@ module Calyx
     end
 
     def write(klass)
-      @narrative ||= []
       @narrative << klass.new.generate
     end
 
     def conditional_write(condition, klass_a, klass_b = nil)
-      @narrative ||= []
       if condition
         @narrative << klass_a.new.generate
       elsif klass_b

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -1,4 +1,5 @@
 module Calyx
+  #The Grammar class and the Production module was written by Mark Rickerby in 2015, and licensed under the MIT license.
   class Grammar
     class << self
       attr_accessor :registry
@@ -174,6 +175,7 @@ module Calyx
     end
   end
 
+  #The DataTemplate class was written by Tariq Ali in 2016, and licensed under the MIT License.
   class DataTemplate
     attr_reader :narrative
 

--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -177,7 +177,7 @@ module Calyx
   class DataTemplate
     attr_reader :narrative
 
-    def initialize(data_hash)
+    def initialize(data_hash = {})
       data_hash.each do |key, value|
         self.define_singleton_method(:"#{key}") do
           value

--- a/lib/calyx/version.rb
+++ b/lib/calyx/version.rb
@@ -1,3 +1,3 @@
 module Calyx
-  VERSION = '0.5.2'.freeze
+  VERSION = '0.6.2'.freeze
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -107,8 +107,8 @@ describe Calyx::DataTemplate do
       happy_sentence = DataTemplate.new(happy_data)
       sad_sentence = DataTemplate.new(sad_data)
 
-      expect(happy_sentence.publish).to eq("I am happy.")
-      expect(sad_sentence.publish).to eq("I am sad.")
+      expect(happy_sentence.result).to eq("I am happy.")
+      expect(sad_sentence.result).to eq("I am sad.")
     end
 
     it 'can handle single operations' do
@@ -121,8 +121,8 @@ describe Calyx::DataTemplate do
       happy_sentence = DataTemplate.new(happy_data)
       sad_sentence = DataTemplate.new(sad_data)
 
-      expect(happy_sentence.publish).to eq("I am happy.")
-      expect(sad_sentence.publish).to eq("")
+      expect(happy_sentence.result).to eq("I am happy.")
+      expect(sad_sentence.result).to eq("")
     end
 
     it 'can write without conditions' do
@@ -133,7 +133,7 @@ describe Calyx::DataTemplate do
       end
 
       happy_sentence = DataTemplate.new(happy_data)
-      expect(happy_sentence.publish).to eq("I am happy.")
+      expect(happy_sentence.result).to eq("I am happy.")
     end
 
     it 'can substitute in data' do
@@ -150,7 +150,7 @@ describe Calyx::DataTemplate do
       stock_data = { :name => "Cyberdyne", :price => 1897.0, :date => Date.new(2015,1,14) }
 
       stock_report = DataTemplate.new(stock_data)
-      expect(stock_report.publish).to eq("The price of one share of Cyberdyne on 2015-01-14 is 1897.0 Yen.")
+      expect(stock_report.result).to eq("The price of one share of Cyberdyne on 2015-01-14 is 1897.0 Yen.")
 
     end
 

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -123,5 +123,15 @@ describe Calyx::DataTemplate do
       expect(sad_sentence.publish).to eq("")
     end
 
+    it 'can write without conditions' do
+      class DataTemplate < Calyx::DataTemplate
+        def write_narrative
+          write Happy
+        end
+      end
+
+      happy_sentence = DataTemplate.new(happy_data)
+      expect(happy_sentence.publish).to eq("I am happy.")
+    end
 
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Calyx do
+describe Calyx::Grammar do
   specify 'construct non-terminal production rule' do
     terminal = double('terminal')
     expect(terminal).to receive(:evaluate)
@@ -83,8 +83,9 @@ describe Calyx do
     grammar = StringFormatters.new(12345)
     expect(grammar.generate).to eq('Hello world')
   end
+end
 
-  specify 'Template class' do
+describe Calyx::DataTemplate do
     class Happy < Calyx::Grammar
       start 'I am happy.'
     end
@@ -92,19 +93,20 @@ describe Calyx do
       start 'I am sad.'
     end
 
-    class DataTemplate < Calyx::DataTemplate
-      def write_narrative
-        write data[:mood] == :happy, Happy, Sad
-      end
-    end
-
     happy_data = {:mood => :happy }
     sad_data = { :mood => :sad }
 
-    happy_sentence = DataTemplate.new(happy_data)
-    sad_sentence = DataTemplate.new(sad_data)
+    it 'can handle tenary operations' do
+      class DataTemplate < Calyx::DataTemplate
+        def write_narrative
+          write data[:mood] == :happy, Happy, Sad
+        end
+      end
+      happy_sentence = DataTemplate.new(happy_data)
+      sad_sentence = DataTemplate.new(sad_data)
 
-    expect(happy_sentence.publish).to eq("I am happy.")
-    expect(sad_sentence.publish).to eq("I am sad.")
-  end
+      expect(happy_sentence.publish).to eq("I am happy.")
+      expect(sad_sentence.publish).to eq("I am sad.")
+    end
+
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -169,5 +169,20 @@ describe Calyx::DataTemplate do
         expect{ happy_sentence.price }.to raise_error(NoMethodError)
         expect{ stock_report.mood }.to raise_error(NoMethodError)
 
+    end
+
+    it "can still write sentences without needing a data hash" do
+      class HelloWorld < Calyx::Grammar
+        start "Hello World."
       end
+
+      class DataTemplate < Calyx::DataTemplate
+        def write_narrative
+          write HelloWorld
+        end
+      end
+
+      hello = DataTemplate.new
+      expect(hello.result).to eq("Hello World.")
+    end
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -109,4 +109,19 @@ describe Calyx::DataTemplate do
       expect(sad_sentence.publish).to eq("I am sad.")
     end
 
+    it 'can handle single operations' do
+      class DataTemplate < Calyx::DataTemplate
+        def write_narrative
+          write data[:mood] == :happy, Happy
+        end
+      end
+
+      happy_sentence = DataTemplate.new(happy_data)
+      sad_sentence = DataTemplate.new(sad_data)
+
+      expect(happy_sentence.publish).to eq("I am happy.")
+      expect(sad_sentence.publish).to eq("")
+    end
+
+
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'date'
+require 'erb'
 
 describe Calyx::Grammar do
   specify 'construct non-terminal production rule' do
@@ -133,5 +135,24 @@ describe Calyx::DataTemplate do
       happy_sentence = DataTemplate.new(happy_data)
       expect(happy_sentence.publish).to eq("I am happy.")
     end
+
+    it 'can substitute in data' do
+      class StockReport < Calyx::Grammar
+        start 'The price of one share of <%= name %> is <%= price %> Yen.'
+      end
+
+      class DataTemplate < Calyx::DataTemplate
+        def write_narrative
+          write StockReport
+        end
+      end
+
+      stock_data = { :name => "Cyberdyne", :price => 1897.0 }
+
+      stock_report = DataTemplate.new(stock_data)
+      expect(stock_report.publish).to eq("The price of one share of Cyberdyne is 1897.0 Yen.")
+
+    end
+
 
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -97,6 +97,8 @@ describe Calyx::DataTemplate do
 
     happy_data = {:mood => :happy }
     sad_data = { :mood => :sad }
+    stock_data = { :name => "Cyberdyne", :price => 1897.0, :date => Date.new(2015,1,14) }
+
 
     it 'can handle tenary operations' do
       class DataTemplate < Calyx::DataTemplate
@@ -154,5 +156,20 @@ describe Calyx::DataTemplate do
 
     end
 
+    it 'each instance of a DataTemplate class will produce its own unique methods based on a specified "data hash"' do
+        class DataTemplate < Calyx::DataTemplate
+          def write_narrative
+            write Happy
+          end
+        end
 
+        happy_sentence = DataTemplate.new(happy_data)
+        stock_report = DataTemplate.new(stock_data)
+
+        expect(happy_sentence.mood).to eq(:happy)
+        expect(stock_report.price).to eq(1897.0)
+        expect{ happy_sentence.price }.to raise_error(NoMethodError)
+        expect{ stock_report.mood }.to raise_error(NoMethodError)
+
+      end
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -138,7 +138,7 @@ describe Calyx::DataTemplate do
 
     it 'can substitute in data' do
       class StockReport < Calyx::Grammar
-        start 'The price of one share of <%= name %> is <%= price %> Yen.'
+        start 'The price of one share of <%= name %> on <%= date %> is <%= price %> Yen.'
       end
 
       class DataTemplate < Calyx::DataTemplate
@@ -147,10 +147,10 @@ describe Calyx::DataTemplate do
         end
       end
 
-      stock_data = { :name => "Cyberdyne", :price => 1897.0 }
+      stock_data = { :name => "Cyberdyne", :price => 1897.0, :date => Date.new(2015,1,14) }
 
       stock_report = DataTemplate.new(stock_data)
-      expect(stock_report.publish).to eq("The price of one share of Cyberdyne is 1897.0 Yen.")
+      expect(stock_report.publish).to eq("The price of one share of Cyberdyne on 2015-01-14 is 1897.0 Yen.")
 
     end
 

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -93,9 +93,8 @@ describe Calyx do
     end
 
     class DataTemplate < Calyx::DataTemplate
-      def generate
+      def write_narrative
         write data[:mood] == :happy, Happy, Sad
-        super
       end
     end
 

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -104,7 +104,7 @@ describe Calyx do
     happy_sentence = DataTemplate.new(happy_data)
     sad_sentence = DataTemplate.new(sad_data)
 
-    expect(happy_sentence.generate).to eq("I am happy.")
-    expect(sad_sentence.generate).to eq("I am sad.")
+    expect(happy_sentence.publish).to eq("I am happy.")
+    expect(sad_sentence.publish).to eq("I am sad.")
   end
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -99,7 +99,7 @@ describe Calyx::DataTemplate do
     it 'can handle tenary operations' do
       class DataTemplate < Calyx::DataTemplate
         def write_narrative
-          write data[:mood] == :happy, Happy, Sad
+          write mood == :happy, Happy, Sad
         end
       end
       happy_sentence = DataTemplate.new(happy_data)
@@ -112,7 +112,7 @@ describe Calyx::DataTemplate do
     it 'can handle single operations' do
       class DataTemplate < Calyx::DataTemplate
         def write_narrative
-          write data[:mood] == :happy, Happy
+          write mood == :happy, Happy
         end
       end
 

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -83,4 +83,29 @@ describe Calyx do
     grammar = StringFormatters.new(12345)
     expect(grammar.generate).to eq('Hello world')
   end
+
+  specify 'Template class' do
+    class Happy < Calyx::Grammar
+      start 'I am happy.'
+    end
+    class Sad < Calyx::Grammar
+      start 'I am sad.'
+    end
+
+    class DataTemplate < Calyx::DataTemplate
+      def generate
+        write data[:mood] == :happy, Happy, Sad
+        super
+      end
+    end
+
+    happy_data = {:mood => :happy }
+    sad_data = { :mood => :sad }
+
+    happy_sentence = DataTemplate.new(happy_data)
+    sad_sentence = DataTemplate.new(sad_data)
+
+    expect(happy_sentence.generate).to eq("I am happy.")
+    expect(sad_sentence.generate).to eq("I am sad.")
+  end
 end

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -149,8 +149,6 @@ describe Calyx::DataTemplate do
         end
       end
 
-      stock_data = { :name => "Cyberdyne", :price => 1897.0, :date => Date.new(2015,1,14) }
-
       stock_report = DataTemplate.new(stock_data)
       expect(stock_report.result).to eq("The price of one share of Cyberdyne on 2015-01-14 is 1897.0 Yen.")
 

--- a/spec/calyx_spec.rb
+++ b/spec/calyx_spec.rb
@@ -99,7 +99,7 @@ describe Calyx::DataTemplate do
     it 'can handle tenary operations' do
       class DataTemplate < Calyx::DataTemplate
         def write_narrative
-          write mood == :happy, Happy, Sad
+          conditional_write mood == :happy, Happy, Sad
         end
       end
       happy_sentence = DataTemplate.new(happy_data)
@@ -112,7 +112,7 @@ describe Calyx::DataTemplate do
     it 'can handle single operations' do
       class DataTemplate < Calyx::DataTemplate
         def write_narrative
-          write mood == :happy, Happy
+          conditional_write mood == :happy, Happy
         end
       end
 


### PR DESCRIPTION
I have not yet written any documentation yet for this feature, but I just want to know whether this feature might be useful enough to merge into master. I have written tests to illustrate how data is to be fed into a new "DataTemplate" class that will decide what Calyx Grammar to invoke.

I will disclose that my pull request does have an ulterior motive. There is currently no open source library that can perform  the same functionality as [Automated Insights' Wordsmith](https://automatedinsights.com), so I hope that these commits could turn Calyx into a possible competitor. Certainly you can perform what Wordsmith does by manually typing out if/else statements (as I did in ["The Atheists Who Believe In God"](https://github.com/tra38/The-Atheists-Who-Believe-In-God), my entry for NaNoGenMo 2015), but it seems more convenient if this process can be abstracted away.