### PR TITLE
File conversions for JSON and YAML

### DIFF
--- a/lib/calyx.rb
+++ b/lib/calyx.rb
@@ -1,5 +1,6 @@
 require_relative 'calyx/version'
 require_relative 'calyx/grammar'
+require_relative 'calyx/file_converter'
 require_relative 'calyx/grammar/registry'
 require_relative 'calyx/grammar/production/choices'
 require_relative 'calyx/grammar/production/concat'

--- a/lib/calyx/file_converter.rb
+++ b/lib/calyx/file_converter.rb
@@ -4,8 +4,20 @@ require 'json'
 module Calyx
   class Grammar
     class << self
+      def load(filename)
+        file = File.read(filename)
+        extension = File.extname(filename)
+        if extension == ".yml"
+          load_yml(file)
+        elsif extension == ".json"
+          load_json(file)
+        else
+          raise "We have not implemented this feature yet."
+        end
+      end
+
       def load_yml(file)
-        yaml = YAML.load_file(file)
+        yaml = YAML.load(file)
         create_calyx_class(yaml)
       end
 

--- a/lib/calyx/file_converter.rb
+++ b/lib/calyx/file_converter.rb
@@ -12,7 +12,7 @@ module Calyx
         elsif extension == ".json"
           load_json(file)
         else
-          raise "We have not implemented this feature yet."
+          raise "Cannot convert #{extension} files."
         end
       end
 

--- a/lib/calyx/file_converter.rb
+++ b/lib/calyx/file_converter.rb
@@ -1,0 +1,47 @@
+require 'yaml'
+require 'json'
+
+module Calyx
+  class Grammar
+    class << self
+      def load_yml(file)
+        yaml = YAML.load_file(file)
+        create_calyx_class(yaml)
+      end
+
+      def load_json(file)
+        json = JSON.parse(file)
+        json.each do |key, value|
+          if value[0] == ":"
+            json[key] = convert_to_symbol(value)
+          elsif value.is_a?(Array)
+            json[key] = parse_array(value)
+          end
+        end
+        create_calyx_class(json)
+      end
+
+      def create_calyx_class(hash)
+        klass = Class.new(Calyx::Grammar)
+        hash.each do |rule_name, rule_productions|
+          klass.send(rule_name, *rule_productions)
+        end
+        klass.new
+      end
+
+      def parse_array(array)
+        array.map do |element|
+          if element[0] == ":"
+            convert_to_symbol(element)
+          else
+            element
+          end
+        end
+      end
+
+      def convert_to_symbol(value)
+        value[1..-1].to_sym
+      end
+    end
+  end
+end

--- a/lib/calyx/grammar.rb
+++ b/lib/calyx/grammar.rb
@@ -1,48 +1,6 @@
-require 'yaml'
-require 'json'
-
 module Calyx
   class Grammar
     class << self
-      def load_yml(file)
-        yaml = YAML.load_file(file)
-        create_calyx_class(yaml)
-      end
-
-      def load_json(file)
-        json = JSON.parse(file)
-        json.each do |key, value|
-          if value[0] == ":"
-            json[key] = convert_to_symbol(value)
-          elsif value.is_a?(Array)
-            json[key] = parse_array(value)
-          end
-        end
-        create_calyx_class(json)
-      end
-
-      def create_calyx_class(hash)
-        klass = Class.new(Calyx::Grammar)
-        hash.each do |rule_name, rule_productions|
-          klass.send(rule_name, *rule_productions)
-        end
-        klass.new
-      end
-
-      def parse_array(array)
-        array.map do |element|
-          if element[0] == ":"
-            convert_to_symbol(element)
-          else
-            element
-          end
-        end
-      end
-
-      def convert_to_symbol(value)
-        value[1..-1].to_sym
-      end
-
       def registry
         @registry ||= Registry.new
       end

--- a/lib/calyx/grammar.rb
+++ b/lib/calyx/grammar.rb
@@ -13,7 +13,9 @@ module Calyx
         json = JSON.parse(file)
         json.each do |key, value|
           if value[0] == ":"
-            json[key] = value[1..-1].to_sym
+            json[key] = convert_to_symbol(value)
+          elsif value.is_a?(Array)
+            json[key] = parse_array(value)
           end
         end
         create_calyx_class(json)
@@ -25,6 +27,20 @@ module Calyx
           klass.send(rule_name, *rule_productions)
         end
         klass.new
+      end
+
+      def parse_array(array)
+        array.map do |element|
+          if element[0] == ":"
+            convert_to_symbol(element)
+          else
+            element
+          end
+        end
+      end
+
+      def convert_to_symbol(value)
+        value[1..-1].to_sym
       end
 
       def registry

--- a/lib/calyx/grammar.rb
+++ b/lib/calyx/grammar.rb
@@ -1,6 +1,32 @@
+require 'yaml'
+require 'json'
+
 module Calyx
   class Grammar
     class << self
+      def load_yml(file)
+        yaml = YAML.load_file(file)
+        create_calyx_class(yaml)
+      end
+
+      def load_json(file)
+        json = JSON.parse(file)
+        json.each do |key, value|
+          if value[0] == ":"
+            json[key] = value[1..-1].to_sym
+          end
+        end
+        create_calyx_class(json)
+      end
+
+      def create_calyx_class(hash)
+        klass = Class.new(Calyx::Grammar)
+        hash.each do |rule_name, rule_productions|
+          klass.send(rule_name, *rule_productions)
+        end
+        klass.new
+      end
+
       def registry
         @registry ||= Registry.new
       end

--- a/spec/load_json_spec.rb
+++ b/spec/load_json_spec.rb
@@ -14,6 +14,20 @@ describe "#load_json" do
     expect(grammar.generate).to eq("Hello World")
   end
 
+  specify 'construct a Calyx::Grammar that can handle multiple references to other rules' do
+    json_text = <<-EOF
+    {
+      "start": [":dragon_wins",":hero_wins"],
+      "dragon_wins": "Dragon Wins",
+      "hero_wins": "Hero Wins"
+    }
+    EOF
+    grammar = Calyx::Grammar.load_json(json_text)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["Dragon Wins","Hero Wins"])
+  end
+
   specify 'construct a Calyx::Grammar class using a JSON file that can handle multiple parameters' do
     json_text = <<-EOF
     {

--- a/spec/load_json_spec.rb
+++ b/spec/load_json_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe "#load_json" do
+
+  specify 'construct a Calyx::Grammar class using a JSON file that references other rules' do
+    json_text = <<-EOF
+    {
+      "start": ":hello_world",
+      "hello_world": ":statement",
+      "statement": "Hello World"
+    }
+    EOF
+    grammar = Calyx::Grammar.load_json(json_text)
+    expect(grammar.generate).to eq("Hello World")
+  end
+
+  specify 'construct a Calyx::Grammar class using a JSON file that can handle multiple parameters' do
+    json_text = <<-EOF
+    {
+      "start": "{fruit}",
+      "fruit": ["apple","orange"]
+    }
+    EOF
+    grammar = Calyx::Grammar.load_json(json_text)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["apple","orange"])
+  end
+
+  specify "construct a Calyx::Grammar class with weighted choices" do
+    json_text = <<-EOF
+    {
+      "start": [["60%", 0.6], ["40%", 0.4]]
+    }
+    EOF
+    grammar = Calyx::Grammar.load_json(json_text)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["40%","60%"])
+  end
+
+  specify 'construct a Calyx::Grammar class but raise an error if weighted choices do not equal 1' do
+    json_text = <<-EOF
+    {
+      "start": [["90%", 0.9], ["80%", 0.8]]
+    }
+    EOF
+    expect do
+      Calyx::Grammar.load_json(json_text)
+    end.to raise_error('Weights must sum to 1')
+
+  end
+
+end

--- a/spec/load_spec.rb
+++ b/spec/load_spec.rb
@@ -31,7 +31,7 @@ describe "#load" do
     allow(File).to receive(:read).with(file_name).and_return(mystery)
     expect do
       Calyx::Grammar.load(file_name)
-    end.to raise_error('We have not implemented this feature yet.')
+    end.to raise_error('Cannot convert .mystery files.')
   end
 
 end

--- a/spec/load_spec.rb
+++ b/spec/load_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe "#load" do
+  specify 'can load a YAML file properly' do
+      yaml = <<-EOF
+      start: "Hello World"
+      EOF
+    file_name = "example.yml"
+    allow(File).to receive(:read).with(file_name).and_return(yaml)
+    grammar = Calyx::Grammar.load(file_name)
+    expect(grammar.generate).to eq("Hello World")
+  end
+
+  specify "can load a JSON file properly" do
+      json = <<-EOF
+      {
+        "start": "Hello World"
+      }
+      EOF
+      file_name = "example.json"
+      allow(File).to receive(:read).with(file_name).and_return(json)
+      grammar = Calyx::Grammar.load(file_name)
+      expect(grammar.generate).to eq("Hello World")
+  end
+
+  specify "raises error if given a file that it cannot parse" do
+    mystery = <<-EOF
+    ? start: "Hello World" ¿
+    EOF
+    file_name = "example.mystery"
+    allow(File).to receive(:read).with(file_name).and_return(mystery)
+    expect do
+      Calyx::Grammar.load(file_name)
+    end.to raise_error('We have not implemented this feature yet.')
+  end
+
+end

--- a/spec/load_yml_spec.rb
+++ b/spec/load_yml_spec.rb
@@ -15,6 +15,23 @@ describe "#load_yml" do
     expect(grammar.generate).to eq("Hello World")
   end
 
+  specify 'construct a Calyx::Grammar that can handle multiple references to other rules' do
+    yaml_text = <<-EOF
+    start:
+      - :dragon_wins
+      - :hero_wins
+    dragon_wins: "Dragon Wins"
+    hero_wins: "Hero Wins"
+    EOF
+    yaml = YAML.load(yaml_text)
+    filepath = "test.yml"
+    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+    grammar = Calyx::Grammar.load_yml(filepath)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["Dragon Wins","Hero Wins"])
+  end
+
   specify 'construct a Calyx::Grammar class using a YAML file that can handle multiple parameters' do
     yaml_text = <<-EOF
     start: "{fruit}"

--- a/spec/load_yml_spec.rb
+++ b/spec/load_yml_spec.rb
@@ -3,77 +3,62 @@ require 'spec_helper'
 describe "#load_yml" do
 
   specify 'construct a Calyx::Grammar class using a YAML file that references other rules' do
-    yaml_text = <<-EOF
+    yaml = <<-EOF
     start: :hello_world
     hello_world: :statement
     statement: "Hello World"
     EOF
-    yaml = YAML.load(yaml_text)
-    filepath = "test.yml"
-    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
-    grammar = Calyx::Grammar.load_yml(filepath)
+    grammar = Calyx::Grammar.load_yml(yaml)
     expect(grammar.generate).to eq("Hello World")
   end
 
   specify 'construct a Calyx::Grammar that can handle multiple references to other rules' do
-    yaml_text = <<-EOF
+    yaml = <<-EOF
     start:
       - :dragon_wins
       - :hero_wins
     dragon_wins: "Dragon Wins"
     hero_wins: "Hero Wins"
     EOF
-    yaml = YAML.load(yaml_text)
-    filepath = "test.yml"
-    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
-    grammar = Calyx::Grammar.load_yml(filepath)
+    grammar = Calyx::Grammar.load_yml(yaml)
     array = []
     10.times { array << grammar.generate }
     expect(array.uniq.sort).to eq(["Dragon Wins","Hero Wins"])
   end
 
   specify 'construct a Calyx::Grammar class using a YAML file that can handle multiple parameters' do
-    yaml_text = <<-EOF
+    yaml = <<-EOF
     start: "{fruit}"
     fruit:
       - apple
       - orange
     EOF
-    yaml = YAML.load(yaml_text)
-    filepath = "test.yml"
-    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
-    grammar = Calyx::Grammar.load_yml(filepath)
+    grammar = Calyx::Grammar.load_yml(yaml)
     array = []
     10.times { array << grammar.generate }
     expect(array.uniq.sort).to eq(["apple","orange"])
   end
 
   specify 'construct a Calyx::Grammar class with weighted choices' do
-    yaml_text = <<-EOF
+    yaml = <<-EOF
     start:
       - [60%, 0.6]
       - [40%, 0.4]
     EOF
-    yaml = YAML.load(yaml_text)
-    filepath = "test.yml"
-    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
-    grammar = Calyx::Grammar.load_yml(filepath)
+    grammar = Calyx::Grammar.load_yml(yaml)
     array = []
     10.times { array << grammar.generate }
     expect(array.uniq.sort).to eq(["40%","60%"])
   end
 
   specify 'construct a Calyx::Grammar class but raise an error if weighted choices do not equal 1' do
-    yaml_text = <<-EOF
+    yaml = <<-EOF
     start:
       - [90%, 0.9]
       - [80%, 0.8]
     EOF
-    yaml = YAML.load(yaml_text)
-    filepath = "test.yml"
-    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
     expect do
-      Calyx::Grammar.load_yml(filepath)
+      Calyx::Grammar.load_yml(yaml)
     end.to raise_error('Weights must sum to 1')
   end
 

--- a/spec/load_yml_spec.rb
+++ b/spec/load_yml_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe "#load_yml" do
+
+  specify 'construct a Calyx::Grammar class using a YAML file that references other rules' do
+    yaml_text = <<-EOF
+    start: :hello_world
+    hello_world: :statement
+    statement: "Hello World"
+    EOF
+    yaml = YAML.load(yaml_text)
+    filepath = "test.yml"
+    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+    grammar = Calyx::Grammar.load_yml(filepath)
+    expect(grammar.generate).to eq("Hello World")
+  end
+
+  specify 'construct a Calyx::Grammar class using a YAML file that can handle multiple parameters' do
+    yaml_text = <<-EOF
+    start: "{fruit}"
+    fruit:
+      - apple
+      - orange
+    EOF
+    yaml = YAML.load(yaml_text)
+    filepath = "test.yml"
+    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+    grammar = Calyx::Grammar.load_yml(filepath)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["apple","orange"])
+  end
+
+  specify 'construct a Calyx::Grammar class with weighted choices' do
+    yaml_text = <<-EOF
+    start:
+      - [60%, 0.6]
+      - [40%, 0.4]
+    EOF
+    yaml = YAML.load(yaml_text)
+    filepath = "test.yml"
+    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+    grammar = Calyx::Grammar.load_yml(filepath)
+    array = []
+    10.times { array << grammar.generate }
+    expect(array.uniq.sort).to eq(["40%","60%"])
+  end
+
+  specify 'construct a Calyx::Grammar class but raise an error if weighted choices do not equal 1' do
+    yaml_text = <<-EOF
+    start:
+      - [90%, 0.9]
+      - [80%, 0.8]
+    EOF
+    yaml = YAML.load(yaml_text)
+    filepath = "test.yml"
+    allow(YAML).to receive(:load_file).with(filepath).and_return(yaml)
+    expect do
+      Calyx::Grammar.load_yml(filepath)
+    end.to raise_error('Weights must sum to 1')
+  end
+
+
+end


### PR DESCRIPTION
Submitting this for code review. I may have to refactor some of the test code in the future, especially as we don't know what other edge cases may exist with JSON/YAML. I suspect that we may have more edge cases with JSON than we do with YAML.

I do note that one major difference between the two methods is that load_yml takes the name of a filename while load_json takes the raw JSON file in and of itself. Should both methods behave consistently?

(See Issue #7 for more details)