### PR TITLE
Fix bug where users cannot create custom filters when using Class Syntax

### DIFF
--- a/lib/calyx/grammar.rb
+++ b/lib/calyx/grammar.rb
@@ -49,7 +49,7 @@ module Calyx
       # @param [Symbol] name
       # @block block with a single string argument returning a modified string.
       def filter(name, &block)
-        registry.mapping(name, &block)
+        registry.filter(name, &block)
       end
 
       # DSL helper method for registering a new grammar rule.

--- a/spec/grammar/mapping_spec.rb
+++ b/spec/grammar/mapping_spec.rb
@@ -27,6 +27,20 @@ describe Calyx::Grammar do
       expect(grammar.generate).to eq('nouns')
     end
 
+    it 'define custom filters using the Class syntax' do
+      class Filter < Calyx::Grammar
+        filter :pluralise do |input|
+          "#{input}s"
+        end
+        start '{noun.pluralise}'
+        noun 'noun'
+      end
+
+      grammar = Filter.new
+
+      expect(grammar.generate).to eq('nouns')
+    end
+
     it 'modifies expressions with methods from an included module' do
       module Pluralisation
         def pluralise(input)


### PR DESCRIPTION
This resolves issue #17 that I previously reported. Just a simple typo. Not really even sure if the automated test is needed, but it probably wouldn't hurt too much to have (for now).